### PR TITLE
Allowing only running containers for port mapping

### DIFF
--- a/hostports/watcher.go
+++ b/hostports/watcher.go
@@ -127,6 +127,10 @@ func (w *watcher) onChange(version string) error {
 		network := networks[container.NetworkUUID]
 		bridge := ""
 
+		if container.State != "running" {
+			continue
+		}
+
 		if container.HostUUID != host.UUID ||
 			!network.HostPorts ||
 			container.PrimaryIp == "" {


### PR DESCRIPTION
**Problem:**
When there are two containers with the same port mapping are in "stopped" and "running" states respectively, the iptables rules get generated for both the containers. This can lead to traffic black-holing for the running container depending on the order of the rules.

**Fix:**
Allow only running containers to be considered for the port mapping logic.