### PR TITLE
Fix b2d networking

### DIFF
--- a/events/start_handler.go
+++ b/events/start_handler.go
@@ -58,12 +58,20 @@ func getDNSSearch(container *docker.Container) []string {
 	return defaultDomains
 }
 
+func trimDockerPath(p string) string {
+	i := strings.Index(p, "/var/lib/docker")
+	if i > 0 {
+		return p[i:]
+	}
+	return p
+}
+
 func setupResolvConf(container *docker.Container) error {
 	if _, ok := container.Config.Labels[RancherSystemLabelKey]; ok {
 		return nil
 	}
 
-	p := container.ResolvConfPath
+	p := trimDockerPath(container.ResolvConfPath)
 	input, err := os.Open(p)
 	if err != nil {
 		return err

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,5 @@
 FROM rancher/agent-base:v0.2.0
+RUN ln -s / /mnt/sda1
 COPY plugin-manager start.sh /usr/bin/
 ENTRYPOINT ["/usr/bin/start.sh"]
 CMD ["plugin-manager"]

--- a/scripts/package
+++ b/scripts/package
@@ -18,7 +18,7 @@ fi
 
 cp ../bin/plugin-manager .
 
-IMAGE=${REPO}/plugin-manager:${TAG}
+IMAGE=${REPO}/network-manager:${TAG}
 docker build -t ${IMAGE} .
 echo ${IMAGE} > ../dist/images
 echo Built ${IMAGE}


### PR DESCRIPTION
Docker will find the absolute path of /var/lib/docker which on b2d
resolves to /mnt/sda1/var/lib/docker and thus resolv.conf paths have
that in the path.  We hack around this and trim off the /mnt/sda1
part because it is bind mounted to /var/lib/docker in our container.