### PR TITLE
Adding source IP checkes before generating hairpin nat rules

### DIFF
--- a/hostports/watcher.go
+++ b/hostports/watcher.go
@@ -80,8 +80,13 @@ func (p PortRule) iptables() []byte {
 	buf.WriteString(":")
 	buf.WriteString(p.TargetPort)
 
-	buf.WriteString(fmt.Sprintf("\n-A CATTLE_PREROUTING -p %v -m %v --dport %v -m addrtype --dst-type LOCAL -j DNAT --to-destination %v:%v",
-		p.Protocol, p.Protocol, p.SourcePort, p.TargetIP, p.TargetPort))
+	if p.SourceIP == "0.0.0.0" {
+		buf.WriteString(fmt.Sprintf("\n-A CATTLE_PREROUTING -p %v -m %v --dport %v -m addrtype --dst-type LOCAL -j DNAT --to-destination %v:%v",
+			p.Protocol, p.Protocol, p.SourcePort, p.TargetIP, p.TargetPort))
+	} else {
+		buf.WriteString(fmt.Sprintf("\n-A CATTLE_PREROUTING -p %v -m %v --dport %v -d %v -j DNAT --to-destination %v:%v",
+			p.Protocol, p.Protocol, p.SourcePort, p.SourceIP, p.TargetIP, p.TargetPort))
+	}
 
 	buf.WriteString(fmt.Sprintf("\n-A CATTLE_OUTPUT -p %v -m %v --dport %v -m addrtype --dst-type LOCAL -j DNAT --to-destination %v:%v",
 		p.Protocol, p.Protocol, p.SourcePort, p.TargetIP, p.TargetPort))


### PR DESCRIPTION
Previous iptables rules for hairpin don't take into account port mapping to a specific IP. So if the user does the equivalent of `-p 1.1.1.1:80:80` only traffic to 1.1.1.1 should go to 80, but there is a rule that is catching all traffic to `:80`

Fix: If there is an IP address specified, use that one instead of catch all.
