### PR TITLE
Ignore host_ports flag for system containers

### DIFF
--- a/hostports/watcher.go
+++ b/hostports/watcher.go
@@ -15,7 +15,8 @@ import (
 )
 
 var (
-	reapplyEvery = 5 * time.Minute
+	reapplyEvery   = 5 * time.Minute
+	hostPortsLabel = "io.rancher.network.host_ports"
 )
 
 // Watch is used to monitor metadata for changes
@@ -149,7 +150,7 @@ func (w *watcher) onChange(version string) error {
 		}
 
 		if container.HostUUID != host.UUID ||
-			!network.HostPorts ||
+			!(network.HostPorts || (container.System && container.Labels[hostPortsLabel] == "true")) ||
 			container.PrimaryIp == "" {
 			continue
 		}

--- a/trash.conf
+++ b/trash.conf
@@ -12,7 +12,7 @@ github.com/opencontainers/runc	v1.0.0-rc2-96-g4c8007f
 github.com/pkg/errors	v0.8.0-2-g248dadf
 github.com/rancher/cniglue	3db1dfdce1a0ac67c19c6616789f48221a5956a3
 github.com/rancher/event-subscriber	ddef597
-github.com/rancher/go-rancher-metadata	af94a9c004c461f6598a62a3eb83993158f90508
+github.com/rancher/go-rancher-metadata  7209d4967a7579ac810bf952c42bee3ac3b29b3e
 github.com/Sirupsen/logrus	v0.10.0-38-g3ec0642
 github.com/urfave/cli	v1.18.0-84-g3eb41f1
 golang.org/x/net	4cfeeeb

--- a/vendor/github.com/rancher/go-rancher-metadata/main.go
+++ b/vendor/github.com/rancher/go-rancher-metadata/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/rancher/go-rancher-metadata/metadata"
+)
+
+const (
+	metadataUrl = "http://rancher-metadata/2015-12-19"
+)
+
+func main() {
+	m := metadata.NewClient(metadataUrl)
+
+	version := "init"
+
+	for {
+		newVersion, err := m.GetVersion()
+		if err != nil {
+			logrus.Errorf("Error reading metadata version: %v", err)
+		} else if version == newVersion {
+			logrus.Debug("No changes in metadata version")
+		} else {
+			logrus.Debugf("Metadata version has changed, oldVersion=[%s], newVersion=[%s]", version, newVersion)
+			version = newVersion
+		}
+		time.Sleep(5 * time.Second)
+	}
+}

--- a/vendor/github.com/rancher/go-rancher-metadata/metadata/types.go
+++ b/vendor/github.com/rancher/go-rancher-metadata/metadata/types.go
@@ -47,6 +47,7 @@ type Container struct {
 	Ips                      []string          `json:"ips"`
 	Ports                    []string          `json:"ports"`
 	ServiceName              string            `json:"service_name"`
+	ServiceIndex             string            `json:"service_index"`
 	StackName                string            `json:"stack_name"`
 	Labels                   map[string]string `json:"labels"`
 	CreateIndex              int               `json:"create_index"`
@@ -63,6 +64,8 @@ type Container struct {
 	HealthCheckHosts         []string          `json:"health_check_hosts"`
 	NetworkFromContainerUUID string            `json:"network_from_container_uuid"`
 	NetworkUUID              string            `json:"network_uuid"`
+	Links                    map[string]string `json:"links"`
+	System                   bool              `json:"system"`
 }
 
 type Network struct {


### PR DESCRIPTION
**Description:**
In the network configuration/settings, there is a field `host_ports` which control if the user launched containers' ports are exposed on the host. Setting this to `false` means, even if the user has specified an expose port, it shouldn't be.

**Problem:**
Setting this flag to false is affecting all the containers in the environment including the system containers. Hence the VXLAN container port (4789) is not exposed on the host causing problems with cross host networking.

**Fix:**
Ignore this flag for the system containers.



**Test results:**

_Network settings:_
```
root@cattleh1:/# curl rancher-metadata/latest/networks/4/host_ports
falseroot@cattleh1:/#
```

_Container launched with expose ports:_
```
root@cattleh1:/# curl http://172.22.101.201:8080/v2-beta/projects/1a7/containers/1i13 | jq '.ports, .name'
[
  "30001:80/tcp"
]
"testnginx2"
root@cattleh1:/#
```

_No expose rules for this container:_
```
root@cattleh1:/# iptables-save | grep 30001
root@cattleh1:/#
```

_VXLAN container ports still being exposed:_
```
root@cattleh1:/# iptables-save | grep 4789
-A CATTLE_OUTPUT -p udp -m udp --dport 4789 -m addrtype --dst-type LOCAL -j DNAT --to-destination 10.42.96.92:4789
-A CATTLE_PREROUTING ! -i docker0 -p udp -m udp --dport 4789 -j MARK --set-xmark 0x1068/0xffffffff
-A CATTLE_PREROUTING ! -i docker0 -p udp -m udp --dport 4789 -j DNAT --to-destination 10.42.96.92:4789
-A CATTLE_PREROUTING -p udp -m udp --dport 4789 -m addrtype --dst-type LOCAL -j DNAT --to-destination 10.42.96.92:4789
root@cattleh1:/#
```

This PR addresses: https://github.com/rancher/rancher/issues/6977