### PR TITLE
Check system container label value

### DIFF
--- a/events/start_handler.go
+++ b/events/start_handler.go
@@ -13,13 +13,12 @@ import (
 )
 
 const (
-	RancherSystemLabelKey = "io.rancher.container.system"
-	RancherNameserver     = "169.254.169.250"
-	RancherDomain         = "rancher.internal"
-	RancherDNS            = "io.rancher.container.dns"
-	RancherIP             = "io.rancher.container.ip"
-	RancherNetwork        = "io.rancher.container.network"
-	CNILabel              = "io.rancher.cni.network"
+	RancherNameserver = "169.254.169.250"
+	RancherDomain     = "rancher.internal"
+	RancherDNS        = "io.rancher.container.dns"
+	RancherIP         = "io.rancher.container.ip"
+	RancherNetwork    = "io.rancher.container.network"
+	CNILabel          = "io.rancher.cni.network"
 )
 
 type StartHandler struct {
@@ -59,10 +58,6 @@ func getDNSSearch(container *docker.Container) []string {
 }
 
 func setupResolvConf(container *docker.Container) error {
-	if _, ok := container.Config.Labels[RancherSystemLabelKey]; ok {
-		return nil
-	}
-
 	if container.ResolvConfPath == "/etc/resolv.conf" {
 		// Don't shoot ourself in the foot and change our own DNS
 		return nil

--- a/network/manager.go
+++ b/network/manager.go
@@ -113,6 +113,7 @@ func (n *Manager) networkUp(id string, inspect types.ContainerJSON, retryCount i
 	if err != nil {
 		if retryCount < maxRetries {
 			go n.retry(id, retryCount+1)
+			return err
 		}
 		return n.s.recordNetworkUpError(id, startedAt, errors.Wrap(err, "Couldn't bring up network"))
 	}


### PR DESCRIPTION
When deciding to setup resolv.conf, skip if the label
io.rancer.container.system has the value 'rancher-agent', not simply if
the label exists.

Making this change because we are going to start adding
io.rancher.container.system=true to all containers that are part of a
system stack so that we can do scheduling based off the presence of
that label.