### PR TITLE
Reduce network retries from 2 minutes to 30 seconds (every 2 seconds)

### DIFF
--- a/network/manager.go
+++ b/network/manager.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	maxRetries            = 60
+	maxRetries            = 15
 	IPLabel               = "io.rancher.container.ip"
 	LegacyManagedNetLabel = "io.rancher.container.network"
 	CNILabel              = "io.rancher.cni.network"
@@ -95,7 +95,7 @@ func (n *Manager) evaluate(id string, retryCount int) error {
 
 func (n *Manager) retry(id string, retryCount int) {
 	time.Sleep(2 * time.Second)
-	logrus.WithField("cid", id).Infof("Evaluating state from retry")
+	logrus.WithFields(logrus.Fields{"cid": id, "count": retryCount}).Infof("Evaluating state from retry")
 	if err := n.evaluate(id, retryCount); err != nil {
 		logrus.Errorf("Failed to evaluate networking: %v", err)
 	}


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/8043

If there is a failure, the network-manager tries every 2 seconds for 2 minutes before giving up. But the go-agent gives up waiting on the IP, stops the container, and errors out after 1 minute.

So, trying for a full 2 minutes is useless. Because of this timing mismatch, we cannot report the more useful error message from network-manager. instead, we'll just always report "Timeout getting IP".

This change reduces the total number of retries from 60 to 15 and the total time spent retrying to about 30 seconds, so that in case of failure, net-manager can record the error and go-agent can read it.