### PR TITLE
When the network router mac changes container ARP tables can get out of sync

### DIFF
--- a/macsync/macsync.go
+++ b/macsync/macsync.go
@@ -1,7 +1,6 @@
 package macsync
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -10,7 +9,9 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/containernetworking/cni/pkg/ns"
 	"github.com/docker/engine-api/client"
+	"github.com/pkg/errors"
 	"github.com/rancher/go-rancher-metadata/metadata"
+	"github.com/rancher/plugin-manager/network"
 	"github.com/vishvananda/netlink"
 )
 
@@ -53,84 +54,14 @@ func (ms *MACSyncer) syncNTimes() {
 }
 
 func (ms *MACSyncer) doSync() error {
-	networks, err := ms.mc.GetNetworks()
+	networks, _, err := network.LocalNetworks(ms.mc)
 	if err != nil {
-		logrus.Errorf("macsync: error fetching networks from metadata")
-		return err
+		return errors.Wrap(err, "getting local networks")
 	}
 
-	host, err := ms.mc.GetSelfHost()
-	if err != nil {
-		logrus.Errorf("macsync: error fetching self host from metadata")
-		return err
-	}
-
-	containers, err := ms.mc.GetContainers()
-	if err != nil {
-		logrus.Errorf("macsync: error fetching containers from metadata")
-		return err
-	}
-
-	services, err := ms.mc.GetServices()
-	if err != nil {
-		logrus.Errorf("macsync: error fetching services from metadata")
-		return err
-	}
-
-	localNetworks := map[string]bool{}
-	for _, service := range services {
-		// Trick to select the primary service of the network plugin
-		// stack
-		// TODO: Need to check if it's needed for Calico?
-		if !(service.Kind == "networkDriverService" &&
-			service.Name == service.PrimaryServiceName) {
-			continue
-		}
-
-		for _, aContainer := range service.Containers {
-			if aContainer.HostUUID == host.UUID {
-				localNetworks[aContainer.NetworkUUID] = true
-			}
-		}
-	}
-	if len(localNetworks) == 0 {
-		return fmt.Errorf("couldn't find any local networks")
-	}
-	logrus.Debugf("macsync: localNetworks: %v", localNetworks)
-
-	var localNetwork metadata.Network
-	for _, aNetwork := range networks {
-		if _, ok := localNetworks[aNetwork.UUID]; ok {
-			localNetwork = aNetwork
-			break
-		}
-	}
-	logrus.Debugf("macsync: localNetwork: %+v", localNetwork)
-
-	for _, aContainer := range containers {
-		if !(aContainer.HostUUID == host.UUID &&
-			aContainer.State == "running" &&
-			aContainer.ExternalId != "" &&
-			aContainer.PrimaryMacAddress != "" &&
-			aContainer.NetworkUUID == localNetwork.UUID) {
-			continue
-		}
-
-		inspect, err := ms.dc.ContainerInspect(context.Background(), aContainer.ExternalId)
-		if err != nil {
-			logrus.Errorf("macsync: error inspecting container: %v", aContainer.ExternalId)
-			continue
-		}
-
-		containerNSStr := fmt.Sprintf("/proc/%v/ns/net", inspect.State.Pid)
-		netns, err := ns.GetNS(containerNSStr)
-		if err != nil {
-			logrus.Errorf("macsync: failed to open netns %v: %v", containerNSStr, err)
-			continue
-		}
-		defer netns.Close()
-
-		if err := netns.Do(func(_ ns.NetNS) error {
+	var lastError error
+	for _, n := range networks {
+		err := network.ForEachContainerNS(ms.dc, ms.mc, n.UUID, func(aContainer metadata.Container, _ ns.NetNS) error {
 			l, err := netlink.LinkByName("eth0")
 			if err != nil {
 				logrus.Errorf("macsync: for container: %v, could not lookup interface: %v",
@@ -152,10 +83,11 @@ func (ms *MACSyncer) doSync() error {
 				}
 			}
 			return nil
-		}); err != nil {
-			logrus.Errorf("macsync: err=%v", err)
-			continue
+		})
+		if err != nil {
+			lastError = err
 		}
 	}
-	return nil
+
+	return lastError
 }

--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func run(c *cli.Context) error {
 		logrus.Errorf("Failed to start cni config: %v", err)
 	}
 
-	if err := arpsync.Watch(c.String("arpsync-interval"), mClient); err != nil {
+	if err := arpsync.Watch(c.String("arpsync-interval"), mClient, dClient); err != nil {
 		logrus.Errorf("Failed to start arpsync: %v", err)
 	}
 

--- a/network/local.go
+++ b/network/local.go
@@ -1,0 +1,116 @@
+package network
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containernetworking/cni/pkg/ns"
+	"github.com/docker/engine-api/client"
+	"github.com/pkg/errors"
+	"github.com/rancher/go-rancher-metadata/metadata"
+)
+
+func LocalNetworks(mc metadata.Client) ([]metadata.Network, map[string]metadata.Container, error) {
+	networks, err := mc.GetNetworks()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "error fetching networks from metadata")
+	}
+
+	host, err := mc.GetSelfHost()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "error fetching self host from metadata")
+	}
+
+	services, err := mc.GetServices()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "error fetching services from metadata")
+	}
+
+	localNetworks := map[string]bool{}
+	routers := map[string]metadata.Container{}
+	for _, service := range services {
+		// Trick to select the primary service of the network plugin
+		// stack
+		// TODO: Need to check if it's needed for Calico?
+		if !(service.Kind == "networkDriverService" &&
+			service.Name == service.PrimaryServiceName) {
+			continue
+		}
+
+		for _, aContainer := range service.Containers {
+			if aContainer.HostUUID == host.UUID {
+				routers[aContainer.NetworkUUID] = aContainer
+				localNetworks[aContainer.NetworkUUID] = true
+			}
+		}
+	}
+
+	if len(localNetworks) == 0 {
+		return nil, nil, nil
+	}
+
+	ret := []metadata.Network{}
+	for _, aNetwork := range networks {
+		if _, ok := localNetworks[aNetwork.UUID]; ok {
+			ret = append(ret, aNetwork)
+		}
+	}
+
+	return ret, routers, nil
+}
+
+func ForEachContainerNS(dc *client.Client, mc metadata.Client, networkUUID string, f func(metadata.Container, ns.NetNS) error) error {
+	host, err := mc.GetSelfHost()
+	if err != nil {
+		return errors.Wrap(err, "error fetching self host from metadata")
+	}
+
+	containers, err := mc.GetContainers()
+	if err != nil {
+		return errors.Wrap(err, "error fetching containers from metadata")
+	}
+
+	var lastError error
+	for _, aContainer := range containers {
+		if !(aContainer.HostUUID == host.UUID &&
+			aContainer.State == "running" &&
+			aContainer.ExternalId != "" &&
+			aContainer.PrimaryIp != "" &&
+			aContainer.PrimaryMacAddress != "" &&
+			aContainer.NetworkUUID == networkUUID) {
+			continue
+		}
+
+		err := EnterNS(dc, aContainer.ExternalId, func(n ns.NetNS) error {
+			return f(aContainer, n)
+		})
+		if err != nil {
+			lastError = err
+		}
+	}
+
+	return lastError
+}
+
+func EnterNS(dc *client.Client, dockerID string, f func(ns.NetNS) error) error {
+	inspect, err := dc.ContainerInspect(context.Background(), dockerID)
+	if err != nil {
+		return errors.Wrapf(err, "inspecting container: %v", dockerID)
+	}
+
+	containerNSStr := fmt.Sprintf("/proc/%v/ns/net", inspect.State.Pid)
+	netns, err := ns.GetNS(containerNSStr)
+	if err != nil {
+		return errors.Wrapf(err, "failed to open netns %v", containerNSStr)
+	}
+	defer netns.Close()
+
+	err = netns.Do(func(n ns.NetNS) error {
+		return f(n)
+	})
+	if err != nil {
+		return errors.Wrapf(err, "in name ns for container %s", dockerID)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Additionally some code cleanup to reuse code across modules.