### PR TITLE
Don't delete, but just stop oldest duplicate container

### DIFF
--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func run(c *cli.Context) error {
 		return err
 	}
 
-	reaper.CheckMetadata(dClient, true)
+	reaper.CheckMetadata(dClient)
 
 	logrus.Infof("Waiting for metadata")
 	mClient, err := metadata.NewClientAndWait(c.String("metadata-url"))


### PR DESCRIPTION
Previously we would delete DNS and metadata containers if we found that
two of them existed (running or not).  That brakes upgrade as two will
exist during upgrade.  Instead now we just stop the oldest container if
more than one running container is found.  This should never be the case
during upgrade because of stop before start.  The behavior of stopping
the oldest container is needed if you removed a host and add it back in.
In this situation you would have the old metadata container and a new
one running.  Since they both listen on 169.254.169.250 you end up with
issues of new containers talking to old stale metadata (and DNS).  For
this reason we stop the old ones.  Eventually (after instance purge
interval) the stopped metadata/dns containers will get deleted from the
host.