### PR TITLE
Add scheduled IP to OUTPUT NAT rule for container

### DIFF
--- a/hostports/watcher.go
+++ b/hostports/watcher.go
@@ -118,13 +118,16 @@ func (p PortRule) natIptables() []byte {
 	if p.SourceIP == "0.0.0.0" {
 		buf.WriteString(fmt.Sprintf("\n-A CATTLE_PREROUTING -p %v -m %v --dport %v -m addrtype --dst-type LOCAL -j DNAT --to-destination %v:%v",
 			p.Protocol, p.Protocol, p.SourcePort, p.TargetIP, p.TargetPort))
+
+		buf.WriteString(fmt.Sprintf("\n-A CATTLE_OUTPUT -p %v -m %v --dport %v -m addrtype --dst-type LOCAL -j DNAT --to-destination %v:%v",
+			p.Protocol, p.Protocol, p.SourcePort, p.TargetIP, p.TargetPort))
 	} else {
 		buf.WriteString(fmt.Sprintf("\n-A CATTLE_PREROUTING -p %v -m %v --dport %v -d %v -j DNAT --to-destination %v:%v",
 			p.Protocol, p.Protocol, p.SourcePort, p.SourceIP, p.TargetIP, p.TargetPort))
-	}
 
-	buf.WriteString(fmt.Sprintf("\n-A CATTLE_OUTPUT -p %v -m %v --dport %v -m addrtype --dst-type LOCAL -j DNAT --to-destination %v:%v",
-		p.Protocol, p.Protocol, p.SourcePort, p.TargetIP, p.TargetPort))
+		buf.WriteString(fmt.Sprintf("\n-A CATTLE_OUTPUT -p %v -m %v --dport %v -d %v -j DNAT --to-destination %v:%v",
+			p.Protocol, p.Protocol, p.SourcePort, p.SourceIP, p.TargetIP, p.TargetPort))
+	}
 
 	buf.WriteString(fmt.Sprintf("\n-A CATTLE_HOSTPORTS_POSTROUTING -s %v -d %v -p %v -m %v --dport %v -j MASQUERADE",
 		p.TargetIP, p.TargetIP, p.Protocol, p.Protocol, p.TargetPort))


### PR DESCRIPTION
Attempt to add scheduled IP to OUTPUT NAT rule for container, in hope will fix https://github.com/rancher/rancher/issues/11724.

The same patch as in https://github.com/rancher/plugin-manager/pull/125 for v1.6 branch.